### PR TITLE
Fix Copy button padding problem

### DIFF
--- a/src/components/DisplayBox.vue
+++ b/src/components/DisplayBox.vue
@@ -103,8 +103,7 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           ></path>
-          <g class="opacity-0"
-          >
+          <g class="opacity-0">
             <path
               d="M15.9975 5.99988L15.9975 3.99988"
               stroke-width="1.5"
@@ -125,7 +124,7 @@
             ></path>
           </g>
         </svg>
-        <p class="pe-[0.45rem]">Copy</p>
+        <p class="pe-[0.44rem]">Copy</p>
       </button>
       <div
         class="p-1 bg-slate-100 shadow-[inset_0px_4px_6px_rgba(0,0,0,0.1)] grid grid-cols-3 justify-items-center rounded-lg relative group"

--- a/src/components/DisplayBox.vue
+++ b/src/components/DisplayBox.vue
@@ -58,7 +58,7 @@
       </div>
       <button
         @click="copyCode"
-        class="shadow active:translate-y-px duration-200 text-sm font-semibold transition ease-out bg-white dark:bg-zinc-800 dark:text-emerald-500 group text-slate-700 justify-center px-3 py-1 rounded-md flex items-center gap-2 relative"
+        class="shadow active:translate-y-px duration-200 text-sm font-semibold transition ease-out bg-white dark:bg-zinc-800 dark:text-emerald-500 group text-slate-700 justify-center px-1 py-1 rounded-md flex items-center gap-2 relative"
       >
         <div
           v-if="showCopyTooltip"
@@ -69,7 +69,7 @@
           ></div>
           <p class="text-[10px] px-2 py-0.5">Copied</p>
         </div>
-
+        
         <svg
           class="h-8 w-8 stroke-slate-700 dark:stroke-emerald-400 dark:group-hover:stroke-emerald-500 transition group-hover:rotate-[-4deg] group-hover:stroke-slate-800"
           fill="none"
@@ -124,8 +124,7 @@
             ></path>
           </g>
         </svg>
-
-        Copy
+        <p class="pe-2">Copy</p>
       </button>
       <div
         class="p-1 bg-slate-100 shadow-[inset_0px_4px_6px_rgba(0,0,0,0.1)] grid grid-cols-3 justify-items-center rounded-lg relative group"

--- a/src/components/DisplayBox.vue
+++ b/src/components/DisplayBox.vue
@@ -104,7 +104,6 @@
             stroke-linejoin="round"
           ></path>
           <g class="opacity-0"
-          :class="{ 'opacity-100': showCopyTooltip }"
           >
             <path
               d="M15.9975 5.99988L15.9975 3.99988"

--- a/src/components/DisplayBox.vue
+++ b/src/components/DisplayBox.vue
@@ -58,7 +58,7 @@
       </div>
       <button
         @click="copyCode"
-        class="shadow active:translate-y-px duration-200 text-sm font-semibold transition ease-out bg-white dark:bg-zinc-800 dark:text-emerald-500 group text-slate-700 justify-center px-1 py-1 rounded-md flex items-center gap-2 relative"
+        class="shadow active:translate-y-px duration-200 text-sm font-semibold  transition ease-out bg-white dark:bg-zinc-800 dark:text-emerald-500 group text-slate-700 justify-center px-1 py-1 rounded-md flex items-center gap-2 relative"
       >
         <div
           v-if="showCopyTooltip"
@@ -103,7 +103,9 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           ></path>
-          <g class="opacity-0">
+          <g class="opacity-0"
+          :class="{ 'opacity-100': showCopyTooltip }"
+          >
             <path
               d="M15.9975 5.99988L15.9975 3.99988"
               stroke-width="1.5"
@@ -124,7 +126,7 @@
             ></path>
           </g>
         </svg>
-        <p class="pe-2">Copy</p>
+        <p class="pe-[0.45rem]">Copy</p>
       </button>
       <div
         class="p-1 bg-slate-100 shadow-[inset_0px_4px_6px_rgba(0,0,0,0.1)] grid grid-cols-3 justify-items-center rounded-lg relative group"


### PR DESCRIPTION
I have fixed the alignment of the copy button by using rem to add some padding to text "Copy" using `class="pe-[0.44rem]`
![image](https://github.com/user-attachments/assets/37c352ca-b415-4e70-8521-d74bafa35be6)

Extras:
i have an unimplemented feature when the user copied the image url it will show up like the image below by changing the `<g>` opacity to 1
`:class="{ 'opacity-100': showCopyTooltip }"`

![image](https://github.com/user-attachments/assets/d7478d11-9c4b-4524-ab61-0e313da518ee)

but i want your approval first